### PR TITLE
Changed 301 Status Redirect to 307 Status Redirect

### DIFF
--- a/routes/urlShorten.js
+++ b/routes/urlShorten.js
@@ -34,7 +34,7 @@ router.get('/:id', async (req, res) => {
     url.location.push(ip.address());
     await url.save();
 
-    res.writeHead(301, {
+    res.writeHead(307, {
         Location: url.inputUrl
     });
     res.end();


### PR DESCRIPTION
As 301 is a Permanent Redirect Status, the Browser only goes through the server
once, then every time the short link is requested, the browser directly goes to the
original link without going through the server. This makes impossible to log that redirect
in the server and increment the views.